### PR TITLE
🐞 fix(mahiro_report): 修复真寻日报中新番文字缺失

### DIFF
--- a/plugins/mahiro_report/config.py
+++ b/plugins/mahiro_report/config.py
@@ -65,6 +65,7 @@ class WeekDay(BaseModel):
 
 
 class AnimeItem(BaseModel):
+    name: str
     name_cn: str
     images: dict
 

--- a/plugins/mahiro_report/data_source.py
+++ b/plugins/mahiro_report/data_source.py
@@ -123,5 +123,5 @@ class Report:
             anime = Anime(**res.json()[week])
         except IndexError:
             anime = Anime(**res.json()[-1])
-        data_list.extend((data.name_cn, data.image) for data in anime.items)
+        data_list.extend((data.name_cn if data.name_cn else data.name, data.image) for data in anime.items)
         return data_list[:8] if len(data_list) > 8 else data_list

--- a/plugins/mahiro_report/data_source.py
+++ b/plugins/mahiro_report/data_source.py
@@ -123,5 +123,5 @@ class Report:
             anime = Anime(**res.json()[week])
         except IndexError:
             anime = Anime(**res.json()[-1])
-        data_list.extend((data.name_cn if data.name_cn else data.name, data.image) for data in anime.items)
+        data_list.extend((data.name_cn or data.name, data.image) for data in anime.items)
         return data_list[:8] if len(data_list) > 8 else data_list


### PR DESCRIPTION
当新番name_cn为空时使用name作为标题
![image](https://github.com/user-attachments/assets/df520815-a5c9-48e5-8d50-7416fbed2308)
![5f5c507184c2258bd17525cbf1ce910b](https://github.com/user-attachments/assets/d37c3a91-a89e-4f12-a865-840016f5dca1)
