### PR TITLE
fix: 修改60s API域名，避免部分地区无法访问，无法生成真寻日报

### DIFF
--- a/plugins/mahiro_report/data_source.py
+++ b/plugins/mahiro_report/data_source.py
@@ -18,7 +18,7 @@ from .date import get_festivals_dates
 class Report:
     hitokoto_url = "https://v1.hitokoto.cn/?c=a"
     alapi_url = "https://v3.alapi.cn/api/zaobao"
-    six_url = "https://60s-api.viki.moe/v2/60s"
+    six_url = "https://60s-api-cf.viki.moe/v2/60s"
     bili_url = "https://s.search.bilibili.com/main/hotword"
     it_url = "https://www.ithome.com/rss/"
     anime_url = "https://api.bgm.tv/calendar"


### PR DESCRIPTION
根据60s API文档`https://docs.60s-api.viki.moe/`得知，原有域名在部分地区会被墙，因此替换域名
*已知我的苏州移动云服务器会被墙