### PR TITLE
fix(russian): 修复俄罗斯轮盘插件的配置读取

### DIFF
--- a/plugins/russian/__init__.py
+++ b/plugins/russian/__init__.py
@@ -3,6 +3,7 @@ from nonebot.plugin import PluginMetadata
 from nonebot_plugin_alconna import Arparma, Match, UniMsg
 from nonebot_plugin_alconna import At as alcAt
 from nonebot_plugin_session import EventSession
+
 from zhenxun.configs.utils import Command, PluginExtraData, RegisterConfig
 from zhenxun.services.log import logger
 from zhenxun.utils.depends import UserName
@@ -43,7 +44,7 @@ __plugin_meta__ = PluginMetadata(
     """.strip(),
     extra=PluginExtraData(
         author="HibiKier",
-        version="0.2-89d294e",
+        version="0.3",
         menu_type="群内小游戏",
         commands=[
             Command(command="装弹 [子弹数] ?[金额] ?[at]"),

--- a/plugins/russian/data_source.py
+++ b/plugins/russian/data_source.py
@@ -1,13 +1,14 @@
 import contextlib
+from datetime import datetime, timedelta
 import random
 import time
-from datetime import datetime, timedelta
 
 from apscheduler.jobstores.base import JobLookupError
 from nonebot.adapters import Bot
 from nonebot_plugin_alconna import At, UniMessage
 from nonebot_plugin_apscheduler import scheduler
 from pydantic import BaseModel
+
 from zhenxun.configs.config import BotConfig, Config
 from zhenxun.models.group_member_info import GroupInfoUser
 from zhenxun.models.user_console import UserConsole
@@ -18,8 +19,6 @@ from zhenxun.utils.message import MessageUtils
 from zhenxun.utils.platform import PlatformUtils
 
 from .model import RussianUser
-
-base_config = Config.get("russian")
 
 
 class Russian(BaseModel):
@@ -145,7 +144,7 @@ class RussianManage:
             return MessageUtils.build_message(
                 f"现在是 {russian.player1[1]} 发起的对决\n请等待比赛结束后再开始下一轮."
             )
-        max_money = base_config.get("MAX_RUSSIAN_BET_GOLD")
+        max_money = Config.get_config("russian","MAX_RUSSIAN_BET_GOLD")
         if rus.money > max_money:
             return MessageUtils.build_message(f"太多了！单次金额不能超过{max_money}！")
         user = await UserConsole.get_user(rus.player1[0])

--- a/plugins/russian/data_source.py
+++ b/plugins/russian/data_source.py
@@ -144,7 +144,7 @@ class RussianManage:
             return MessageUtils.build_message(
                 f"现在是 {russian.player1[1]} 发起的对决\n请等待比赛结束后再开始下一轮."
             )
-        max_money = Config.get_config("russian","MAX_RUSSIAN_BET_GOLD")
+        max_money = Config.get_config("russian", "MAX_RUSSIAN_BET_GOLD")
         if rus.money > max_money:
             return MessageUtils.build_message(f"太多了！单次金额不能超过{max_money}！")
         user = await UserConsole.get_user(rus.player1[0])

--- a/plugins/russian/model.py
+++ b/plugins/russian/model.py
@@ -27,7 +27,7 @@ class RussianUser(Model):
     max_losing_streak = fields.IntField(default=0)
     """最大连败"""
 
-    class Meta:
+    class Meta: # pyright: ignore[reportIncompatibleVariableOverride]
         table = "russian_users"
         table_description = "俄罗斯轮盘数据表"
         unique_together = ("user_id", "group_id")
@@ -42,30 +42,8 @@ class RussianUser(Model):
             itype: 输或赢 'win' or 'lose'
         """
         user, _ = await cls.get_or_create(user_id=user_id, group_id=group_id)
-        if itype == "win":
-            _max = (
-                user.max_winning_streak
-                if user.max_winning_streak > user.winning_streak + 1
-                else user.winning_streak + 1
-            )
-            user.win_count = user.win_count + 1
-            user.winning_streak = user.winning_streak + 1
-            user.losing_streak = 0
-            user.max_winning_streak = _max
-            await user.save(
-                update_fields=[
-                    "win_count",
-                    "winning_streak",
-                    "losing_streak",
-                    "max_winning_streak",
-                ]
-            )
-        elif itype == "lose":
-            _max = (
-                user.max_losing_streak
-                if user.max_losing_streak > user.losing_streak + 1
-                else user.losing_streak + 1
-            )
+        if itype == "lose":
+            _max = max(user.max_losing_streak, user.losing_streak + 1)
             user.fail_count = user.fail_count + 1
             user.losing_streak = user.losing_streak + 1
             user.winning_streak = 0
@@ -76,6 +54,20 @@ class RussianUser(Model):
                     "winning_streak",
                     "losing_streak",
                     "max_losing_streak",
+                ]
+            )
+        elif itype == "win":
+            _max = max(user.max_winning_streak, user.winning_streak + 1)
+            user.win_count = user.win_count + 1
+            user.winning_streak = user.winning_streak + 1
+            user.losing_streak = 0
+            user.max_winning_streak = _max
+            await user.save(
+                update_fields=[
+                    "win_count",
+                    "winning_streak",
+                    "losing_streak",
+                    "max_winning_streak",
                 ]
             )
         return user
@@ -90,7 +82,7 @@ class RussianUser(Model):
             itype: 输或赢 'win' or 'lose'
             count: 金钱数量
         """
-        user, _ = await cls.get_or_create(user_id=str(user_id), group_id=group_id)
+        user, _ = await cls.get_or_create(user_id=user_id, group_id=group_id)
         if itype == "win":
             user.make_money = user.make_money + count
         elif itype == "lose":
@@ -100,7 +92,7 @@ class RussianUser(Model):
     @classmethod
     async def _run_script(cls):
         return [
-            "ALTER TABLE russian_users RENAME COLUMN user_qq TO user_id;",  # 将user_qq改为user_id
-            "ALTER TABLE russian_users ALTER COLUMN user_id TYPE character varying(255);",
-            "ALTER TABLE russian_users ALTER COLUMN group_id TYPE character varying(255);",
+            "ALTER TABLE russian_users RENAME COLUMN user_qq TO user_id;",
+            "ALTER TABLE russian_users ALTER COLUMN user_id TYPE character varying(255);",  # noqa: E501
+            "ALTER TABLE russian_users ALTER COLUMN group_id TYPE character varying(255);",  # noqa: E501
         ]

--- a/plugins/russian/model.py
+++ b/plugins/russian/model.py
@@ -27,7 +27,7 @@ class RussianUser(Model):
     max_losing_streak = fields.IntField(default=0)
     """最大连败"""
 
-    class Meta: # pyright: ignore[reportIncompatibleVariableOverride]
+    class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
         table = "russian_users"
         table_description = "俄罗斯轮盘数据表"
         unique_together = ("user_id", "group_id")


### PR DESCRIPTION
- 更新插件版本号至 0.3
- 重构部分代码，提高可读性和可维护性
- 优化用户数据统计逻辑，修复了一些潜在的问题
- 添加了对用户 ID 和群组 ID 类型的兼容性改动
- resolve [#2052](https://github.com/zhenxun-org/zhenxun_bot/issues/2052)