### PR TITLE
修正阿里云百炼API的URL路径

### DIFF
--- a/plugins/bym_ai/data_source.py
+++ b/plugins/bym_ai/data_source.py
@@ -363,7 +363,7 @@ class CallApi:
             "gemini": "https://generativelanguage.googleapis.com/v1beta/chat/completions",
             "deepseek": "https://api.deepseek.com/v1/chat/completions",
             "硅基流动": "https://api.siliconflow.cn/v1/chat/completions",
-            "阿里云百炼": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+            "阿里云百炼": "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions",
             "百度智能云": "https://qianfan.baidubce.com/v2",
             "字节火山引擎": "https://ark.cn-beijing.volces.com/api/v3",
         }


### PR DESCRIPTION
我看之前有pr修复了硅基流动的API，但是其他平台的都没修复，应该都是要加/chat/completions才能调用的。我先把阿里云百炼的api修复了，之后作者检查一下其他的吧